### PR TITLE
Rename Cask Market to CDAP Hub. Rename packages to reflect this change.

### DIFF
--- a/LOCALSETUP.md
+++ b/LOCALSETUP.md
@@ -1,17 +1,17 @@
-# Setting Up Cask Market Locally
+# Setting Up CDAP Hub Locally
 
-You need to have some sort of webserver in your machine to serve from a directory. Using [MAMP](https://www.mamp.info/en/) will probably the fastest way to get started. Point your webserver to the cask-marketplace directory.
+You need to have some sort of webserver in your machine to serve from a directory. Using [MAMP](https://www.mamp.info/en/) will probably the fastest way to get started. Point your webserver to the hub repository directory.
 
 
-## Building Market
-1. `cd` into the cask-marketplace repository
+## Building Hub
+1. `cd` into the hub repository
 2. `cd packager`
 3. `mvn clean package`
 4. `cd ..`
-5. `java -cp packager/target/*:packager/target/lib/* co.cask.marketplace.Tool build`
+5. `java -cp packager/target/*:packager/target/lib/* io.cdap.hub.Tool build`
 
 ## Windows
-5. `java -cp .\packager\target\*;.\packager\target\lib\* co.cask.marketplace.Tool build`
+5. `java -cp .\packager\target\*;.\packager\target\lib\* io.cdap.hub.Tool build`
 
 ## Start WebServer 
 ```python -m SimpleHTTPServer```
@@ -24,12 +24,12 @@ You need to have some sort of webserver in your machine to serve from a director
 5. Go to **Web Server** Tab
 6. Make sure Apache is selected
 7. Click on the Folder icon with 3 dots next to Document Root.
-8. Navigate your cask-marketplace directory, and click **Select**
+8. Navigate your cdap directory, and click **Select**
 9. Click **OK**
 10. Click **Start Server**
 
 
-## Changing Cask Market Basepath in CDAP
+## Changing CDAP Hub Basepath in CDAP
 
 ### For CDAP 4.0.x
 Navigate to

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cask Marketplace
+# CDAP Hub
 
 ## Setup
 
@@ -7,7 +7,7 @@ See https://git-lfs.github.com/ for information on installing and settting up gi
 
 ## Directory Structure
 
-The marketplace repository requires this directory structure:
+The Hub repository requires this directory structure:
 
     packages/<name>/<version>/spec.json
     packages/<name>/<version>/icon.jpg
@@ -16,9 +16,9 @@ The marketplace repository requires this directory structure:
 
 Anything that falls under 'other files' will be zipped up by the packager into an 'archive.zip' file.
 
-## Local Market Setup
+## Local Hub Setup
 
-Read the [LOCALSETUP](LOCALSETUP.md) guide to setup Cask Market locally on your machine
+Read the [LOCALSETUP](LOCALSETUP.md) guide to setup CDAP Hub locally on your machine
 
 ## Packager
 
@@ -26,17 +26,18 @@ To build the packager:
 
     cd packager
     mvn clean package
+    cd ..
 
 The packager can be used to create the packages.json catalog file, create 'archive.zip'
 files, sign package specs and archives, and push the package files to s3. You can see the
 help manual by running:
 
-    java -cp packager/target/*:packager/target/lib/* co.cask.marketplace.Tool
+    java -cp packager/target/*:packager/target/lib/* io.cdap.hub.Tool
 
 The packager uses PGP to sign archives and specs. It is therefore compatible with keyrings
 created with GnuPG. For example:
 
-    java -cp packager/target/*:packager/target/lib/* co.cask.marketplace.Tool build -k ~/.gnupg/secring.gpg -i 499BC990789824FD -p mypassword
+    java -cp packager/target/*:packager/target/lib/* io.cdap.hub.Tool build -k ~/.gnupg/secring.gpg -i 499BC990789824FD -p mypassword
 
 This will go through the files under the 'packages' directory, adding a 'packages.json'
 catalog at the top level and adding 'spec.json.asc', 'archive.zip', and 'archive.zip.asc' files:
@@ -53,7 +54,7 @@ catalog at the top level and adding 'spec.json.asc', 'archive.zip', and 'archive
 
 To build all the packages and also push them to s3:
 
-    java -cp packager/target/*:packager/target/lib/* co.cask.marketplace.Tool publish -k <gpg keyring file> -i <keyid> -p <key password> -s3b <s3 bucket> -s3a <s3 access key> -s3s <s3 secret key>
+    java -cp packager/target/*:packager/target/lib/* io.cdap.hub.Tool publish -k <gpg keyring file> -i <keyid> -p <key password> -s3b <s3 bucket> -s3a <s3 access key> -s3s <s3 secret key>
 
 This will build and sign all packages, as well as push anything that has changed to s3.
 The tool will use the md5 and file size to determine whether an object has changed or not.
@@ -96,11 +97,11 @@ everything about the package is the same except for the CDAP version and plugin 
 
 To generate new packages:
 
-    java -cp packager/target/*:packager/target/lib/* co.cask.marketplace.Generator -cv <cdap-version> -gv <plugins-version> -pv <package-version> -bv <base-version> generate
+    java -cp packager/target/*:packager/target/lib/* io.cdap.hub.Generator -cv <cdap-version> -gv <plugins-version> -pv <package-version> -bv <base-version> generate
 
 For example:
 
-    java -cp packager/target/*:packager/target/lib/* co.cask.marketplace.Generator -cv 4.1.0-SNAPSHOT -gv 1.6.0-SNAPSHOT -pv 1.1.0 -bv 1.0.1 generate
+    java -cp packager/target/*:packager/target/lib/* io.cdap.hub.Generator -cv 4.1.0-SNAPSHOT -gv 1.6.0-SNAPSHOT -pv 1.1.0 -bv 1.0.1 generate
 
 will generate new 1.1.0 packages from existing 1.0.1 packages. The `cdapVersion` of the new packages will be `4.1.0-SNAPSHOT`,
 and the artifact version for plugins in pipeline configs will be `1.6.0-SNAPSHOT`. 
@@ -110,7 +111,7 @@ By default, the tool will ignore any beta packages and will only create new pack
 
 The generator can also modify existing packages instead of creating new packages. For example:
 
-    java -cp packager/target/*:packager/target/lib/* co.cask.marketplace.Generator -cv 4.1.0 -gv 1.6.0 -pv 1.1.0 modify
+    java -cp packager/target/*:packager/target/lib/* io.cdap.hub.Generator -cv 4.1.0 -gv 1.6.0 -pv 1.1.0 modify
 
 will modify all 1.1.0 packages to use 4.1.0 as the `cdapVersion` and 1.6.0 as the `plugin version`.
 

--- a/packager/pom.xml
+++ b/packager/pom.xml
@@ -18,12 +18,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 <modelVersion>4.0.0</modelVersion>
 
-  <groupId>co.cask.marketplace</groupId>
-  <artifactId>cask-packager</artifactId>
+  <groupId>io.cdap.hub</groupId>
+  <artifactId>hub-packager</artifactId>
   <version>0.1.0-SNAPSHOT</version>
-  <name>Cask Marketplace Packager</name>
-  <description>Tools to create and publish packages to a CDAP Marketplace.</description>
-  <url>https://github.com/caskdata/cask-marketplace</url>
+  <name>CDAP Hub Packager</name>
+  <description>Tools to create and publish packages to a CDAP Hub.</description>
+  <url>https://github.com/cdapio/hub</url>
 
   <licenses>
     <license>
@@ -36,17 +36,17 @@
 
   <developers>
     <developer>
-      <name>Cask Data</name>
-      <email>cask-dev@googlegroups.com</email>
-      <organization>Cask Data, Inc.</organization>
+      <name>CDAP</name>
+      <email>cdap-dev@googlegroups.com</email>
+      <organization>CDAP</organization>
       <organizationUrl>http://www.cdap.io</organizationUrl>
     </developer>
   </developers>
 
   <scm>
-    <connection>scm:git:https://github.com/caskdata/cask-marketplace.git</connection>
-    <developerConnection>scm:git:git@github.com:caskdata/cask-marketplace.git</developerConnection>
-    <url>https://github.com/caskdata/cask-marketplace.git</url>
+    <connection>scm:git:https://github.com/cdapio/hub.git</connection>
+    <developerConnection>scm:git:git@github.com:cdapio/hub.git</developerConnection>
+    <url>https://github.com/cdapio/hub.git</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/packager/src/main/java/io/cdap/hub/Generator.java
+++ b/packager/src/main/java/io/cdap/hub/Generator.java
@@ -14,11 +14,8 @@
  * the License.
  */
 
-package co.cask.marketplace;
+package io.cdap.hub;
 
-import co.cask.marketplace.spec.ActionArguments;
-import co.cask.marketplace.spec.ActionSpec;
-import co.cask.marketplace.spec.PackageSpec;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
@@ -26,6 +23,9 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import io.cdap.hub.spec.ActionArguments;
+import io.cdap.hub.spec.ActionSpec;
+import io.cdap.hub.spec.PackageSpec;
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;

--- a/packager/src/main/java/io/cdap/hub/Hub.java
+++ b/packager/src/main/java/io/cdap/hub/Hub.java
@@ -14,9 +14,9 @@
  * the License.
  */
 
-package co.cask.marketplace;
+package io.cdap.hub;
 
-import co.cask.marketplace.spec.CategoryMeta;
+import io.cdap.hub.spec.CategoryMeta;
 
 import java.io.File;
 import java.util.List;

--- a/packager/src/main/java/io/cdap/hub/Package.java
+++ b/packager/src/main/java/io/cdap/hub/Package.java
@@ -14,11 +14,11 @@
  * the License.
  */
 
-package co.cask.marketplace;
+package io.cdap.hub;
 
-import co.cask.marketplace.spec.PackageMeta;
-import co.cask.marketplace.spec.PackageSpec;
 import com.google.gson.Gson;
+import io.cdap.hub.spec.PackageMeta;
+import io.cdap.hub.spec.PackageSpec;
 
 import java.io.File;
 import java.io.FileReader;

--- a/packager/src/main/java/io/cdap/hub/PackageId.java
+++ b/packager/src/main/java/io/cdap/hub/PackageId.java
@@ -14,32 +14,28 @@
  * the License.
  */
 
-package co.cask.marketplace;
+package io.cdap.hub;
 
-import java.io.File;
 import java.util.Objects;
-import javax.annotation.Nullable;
 
 /**
- * A pair of a File and its corresponding signature File. The signature is optional.
+ * Package name and version.
  */
-public class SignedFile {
-  private final File file;
-  @Nullable
-  private final File signature;
+public class PackageId {
+  private final String name;
+  private final String version;
 
-  public SignedFile(File file, @Nullable File signature) {
-    this.file = file;
-    this.signature = signature;
+  public PackageId(String name, String version) {
+    this.name = name;
+    this.version = version;
   }
 
-  public File getFile() {
-    return file;
+  public String getName() {
+    return name;
   }
 
-  @Nullable
-  public File getSignature() {
-    return signature;
+  public String getVersion() {
+    return version;
   }
 
   @Override
@@ -51,20 +47,21 @@ public class SignedFile {
       return false;
     }
 
-    SignedFile that = (SignedFile) o;
-    return Objects.equals(file, that.file) && Objects.equals(signature, that.signature);
+    PackageId that = (PackageId) o;
+
+    return Objects.equals(name, that.name) && Objects.equals(version, that.version);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(file, signature);
+    return Objects.hash(name, version);
   }
 
   @Override
   public String toString() {
-    return "SignedFile{" +
-      "file=" + file +
-      ", signature=" + signature +
+    return "PackageId{" +
+      "name='" + name + '\'' +
+      ", version='" + version + '\'' +
       '}';
   }
 }

--- a/packager/src/main/java/io/cdap/hub/Packager.java
+++ b/packager/src/main/java/io/cdap/hub/Packager.java
@@ -14,12 +14,12 @@
  * the License.
  */
 
-package co.cask.marketplace;
+package io.cdap.hub;
 
-import co.cask.marketplace.spec.CategoryMeta;
-import co.cask.marketplace.spec.PackageMeta;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import io.cdap.hub.spec.CategoryMeta;
+import io.cdap.hub.spec.PackageMeta;
 import org.bouncycastle.openpgp.PGPException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +47,7 @@ import java.util.zip.ZipOutputStream;
 import javax.annotation.Nullable;
 
 /**
- * Tool to create and publish packages for a CDAP Marketplace.
+ * Tool to create and publish packages for a CDAP Hub.
  *
  * Expects packages to be under a specific directory structure of:
  *

--- a/packager/src/main/java/io/cdap/hub/Publisher.java
+++ b/packager/src/main/java/io/cdap/hub/Publisher.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.marketplace;
+package io.cdap.hub;
 
 /**
  * Publishes the Hub.

--- a/packager/src/main/java/io/cdap/hub/S3Publisher.java
+++ b/packager/src/main/java/io/cdap/hub/S3Publisher.java
@@ -14,9 +14,8 @@
  * the License.
  */
 
-package co.cask.marketplace;
+package io.cdap.hub;
 
-import co.cask.marketplace.spec.CategoryMeta;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -33,6 +32,7 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.Files;
 import com.google.common.net.MediaType;
+import io.cdap.hub.spec.CategoryMeta;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/packager/src/main/java/io/cdap/hub/SignedFile.java
+++ b/packager/src/main/java/io/cdap/hub/SignedFile.java
@@ -14,28 +14,32 @@
  * the License.
  */
 
-package co.cask.marketplace;
+package io.cdap.hub;
 
+import java.io.File;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
- * Package name and version.
+ * A pair of a File and its corresponding signature File. The signature is optional.
  */
-public class PackageId {
-  private final String name;
-  private final String version;
+public class SignedFile {
+  private final File file;
+  @Nullable
+  private final File signature;
 
-  public PackageId(String name, String version) {
-    this.name = name;
-    this.version = version;
+  public SignedFile(File file, @Nullable File signature) {
+    this.file = file;
+    this.signature = signature;
   }
 
-  public String getName() {
-    return name;
+  public File getFile() {
+    return file;
   }
 
-  public String getVersion() {
-    return version;
+  @Nullable
+  public File getSignature() {
+    return signature;
   }
 
   @Override
@@ -47,21 +51,20 @@ public class PackageId {
       return false;
     }
 
-    PackageId that = (PackageId) o;
-
-    return Objects.equals(name, that.name) && Objects.equals(version, that.version);
+    SignedFile that = (SignedFile) o;
+    return Objects.equals(file, that.file) && Objects.equals(signature, that.signature);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, version);
+    return Objects.hash(file, signature);
   }
 
   @Override
   public String toString() {
-    return "PackageId{" +
-      "name='" + name + '\'' +
-      ", version='" + version + '\'' +
+    return "SignedFile{" +
+      "file=" + file +
+      ", signature=" + signature +
       '}';
   }
 }

--- a/packager/src/main/java/io/cdap/hub/Signer.java
+++ b/packager/src/main/java/io/cdap/hub/Signer.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.marketplace;
+package io.cdap.hub;
 
 import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.bcpg.BCPGOutputStream;

--- a/packager/src/main/java/io/cdap/hub/Tool.java
+++ b/packager/src/main/java/io/cdap/hub/Tool.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.marketplace;
+package io.cdap.hub;
 
 import com.google.common.base.Splitter;
 import com.google.common.io.BaseEncoding;

--- a/packager/src/main/java/io/cdap/hub/spec/ActionArguments.java
+++ b/packager/src/main/java/io/cdap/hub/spec/ActionArguments.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.marketplace.spec;
+package io.cdap.hub.spec;
 
 import com.google.gson.JsonElement;
 

--- a/packager/src/main/java/io/cdap/hub/spec/ActionSpec.java
+++ b/packager/src/main/java/io/cdap/hub/spec/ActionSpec.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.marketplace.spec;
+package io.cdap.hub.spec;
 
 import java.util.List;
 import java.util.Objects;

--- a/packager/src/main/java/io/cdap/hub/spec/CategoryMeta.java
+++ b/packager/src/main/java/io/cdap/hub/spec/CategoryMeta.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.marketplace.spec;
+package io.cdap.hub.spec;
 
 import java.io.File;
 import javax.annotation.Nullable;

--- a/packager/src/main/java/io/cdap/hub/spec/LicenseInfo.java
+++ b/packager/src/main/java/io/cdap/hub/spec/LicenseInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2018 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,18 +14,17 @@
  * the License.
  */
 
-package co.cask.marketplace.spec;
+package io.cdap.hub.spec;
 
 /**
- * An object that can be validated. This is used for objects that can be created through Gson deserialization, to make
- * sure all required fields exist.
+ * Information about a license.
  */
-public interface Validatable {
+public class LicenseInfo {
+  private final String name;
+  private final String url;
 
-  /**
-   * Validate the object.
-   *
-   * @throws IllegalArgumentException if the object is not valid.
-   */
-  void validate();
+  public LicenseInfo(String name, String url) {
+    this.name = name;
+    this.url = url;
+  }
 }

--- a/packager/src/main/java/io/cdap/hub/spec/PackageMeta.java
+++ b/packager/src/main/java/io/cdap/hub/spec/PackageMeta.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.marketplace.spec;
+package io.cdap.hub.spec;
 
 import java.util.Objects;
 import java.util.Set;

--- a/packager/src/main/java/io/cdap/hub/spec/PackageSpec.java
+++ b/packager/src/main/java/io/cdap/hub/spec/PackageSpec.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.marketplace.spec;
+package io.cdap.hub.spec;
 
 import java.util.List;
 import java.util.Objects;

--- a/packager/src/main/java/io/cdap/hub/spec/Validatable.java
+++ b/packager/src/main/java/io/cdap/hub/spec/Validatable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,17 +14,18 @@
  * the License.
  */
 
-package co.cask.marketplace.spec;
+package io.cdap.hub.spec;
 
 /**
- * Information about a license.
+ * An object that can be validated. This is used for objects that can be created through Gson deserialization, to make
+ * sure all required fields exist.
  */
-public class LicenseInfo {
-  private final String name;
-  private final String url;
+public interface Validatable {
 
-  public LicenseInfo(String name, String url) {
-    this.name = name;
-    this.url = url;
-  }
+  /**
+   * Validate the object.
+   *
+   * @throws IllegalArgumentException if the object is not valid.
+   */
+  void validate();
 }


### PR DESCRIPTION
Rename Cask Market to CDAP Hub. Rename packages to reflect this change.

I will update the relevant builds (https://builds.cask.co/browse/CMP), when I merge this PR.