### PR TITLE
(CDAP-16158) Support for Additional Charges flag

### DIFF
--- a/packager/src/main/java/io/cdap/hub/Generator.java
+++ b/packager/src/main/java/io/cdap/hub/Generator.java
@@ -107,7 +107,7 @@ public class Generator {
           if (configs.contains(resource.getName())) {
             LOG.info("copying and modifying {}", resource.getName());
             try (FileReader reader = new FileReader(resource);
-                 FileWriter writer = new FileWriter(newFile)) {
+              FileWriter writer = new FileWriter(newFile)) {
               GSON.toJson(modifyHydratorConfig(GSON.fromJson(reader, JsonObject.class)), writer);
             }
           } else {

--- a/packager/src/main/java/io/cdap/hub/spec/PackageMeta.java
+++ b/packager/src/main/java/io/cdap/hub/spec/PackageMeta.java
@@ -20,10 +20,11 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Metadata about a package. The Packager will create a file containing a list of these, one for each package
- * it created.
+ * Metadata about a package. The Packager will create a file containing a list of these, one for each package it
+ * created.
  */
 public class PackageMeta {
+
   private final String name;
   private final String version;
   private final String description;
@@ -42,7 +43,8 @@ public class PackageMeta {
   public static PackageMeta fromSpec(String name, String version, PackageSpec spec) {
     return new PackageMeta(name, version, spec.getDescription(), spec.getLabel(), spec.getAuthor(), spec.getOrg(),
                            spec.getCdapVersion(), spec.getLicense(), spec.getLicenseInfo(), spec.getCreated(),
-                           spec.getBeta(), spec.getCategories(), spec.getPaid(), spec.getPaidLink());
+                           spec.getBeta(), spec.getCategories(), spec.getPaid(),
+                           spec.getPaidLink());
   }
 
   public PackageMeta(String name, String version, String description, String label, String author, String org,

--- a/packager/src/main/java/io/cdap/hub/spec/PackageMeta.java
+++ b/packager/src/main/java/io/cdap/hub/spec/PackageMeta.java
@@ -36,16 +36,17 @@ public class PackageMeta {
   private final long created;
   private final Boolean beta;
   private final Set<String> categories;
+  private final Boolean paid;
 
   public static PackageMeta fromSpec(String name, String version, PackageSpec spec) {
     return new PackageMeta(name, version, spec.getDescription(), spec.getLabel(), spec.getAuthor(), spec.getOrg(),
                            spec.getCdapVersion(), spec.getLicense(), spec.getLicenseInfo(), spec.getCreated(),
-                           spec.getBeta(), spec.getCategories());
+                           spec.getBeta(), spec.getCategories(), spec.getPaid());
   }
 
   public PackageMeta(String name, String version, String description, String label, String author, String org,
                      String cdapVersion, String license, LicenseInfo licenseInfo,
-                     long created, Boolean beta, Set<String> categories) {
+                     long created, Boolean beta, Set<String> categories, Boolean paid) {
     this.name = name;
     this.version = version;
     this.description = description;
@@ -58,6 +59,7 @@ public class PackageMeta {
     this.license = license;
     this.licenseInfo = licenseInfo;
     this.beta = beta;
+    this.paid = paid;
   }
 
   public String getName() {
@@ -120,13 +122,14 @@ public class PackageMeta {
       Objects.equals(license, that.license) &&
       Objects.equals(created, that.created) &&
       Objects.equals(beta, that.beta) &&
-      Objects.equals(categories, that.categories);
+      Objects.equals(categories, that.categories) &&
+      Objects.equals(paid, that.paid);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(name, version, description, label, author, org, cdapVersion,
-                        license, created, beta, categories);
+                        license, created, beta, categories, paid);
   }
 
   @Override
@@ -143,6 +146,7 @@ public class PackageMeta {
       ", created=" + created +
       ", beta=" + beta +
       ", categories=" + categories +
+      ", paid=" + paid +
       '}';
   }
 }

--- a/packager/src/main/java/io/cdap/hub/spec/PackageMeta.java
+++ b/packager/src/main/java/io/cdap/hub/spec/PackageMeta.java
@@ -37,16 +37,17 @@ public class PackageMeta {
   private final Boolean beta;
   private final Set<String> categories;
   private final Boolean paid;
+  private final String paidLink;
 
   public static PackageMeta fromSpec(String name, String version, PackageSpec spec) {
     return new PackageMeta(name, version, spec.getDescription(), spec.getLabel(), spec.getAuthor(), spec.getOrg(),
                            spec.getCdapVersion(), spec.getLicense(), spec.getLicenseInfo(), spec.getCreated(),
-                           spec.getBeta(), spec.getCategories(), spec.getPaid());
+                           spec.getBeta(), spec.getCategories(), spec.getPaid(), spec.getPaidLink());
   }
 
   public PackageMeta(String name, String version, String description, String label, String author, String org,
                      String cdapVersion, String license, LicenseInfo licenseInfo,
-                     long created, Boolean beta, Set<String> categories, Boolean paid) {
+                     long created, Boolean beta, Set<String> categories, Boolean paid, String paidLink) {
     this.name = name;
     this.version = version;
     this.description = description;
@@ -60,6 +61,7 @@ public class PackageMeta {
     this.licenseInfo = licenseInfo;
     this.beta = beta;
     this.paid = paid;
+    this.paidLink = paidLink;
   }
 
   public String getName() {

--- a/packager/src/main/java/io/cdap/hub/spec/PackageSpec.java
+++ b/packager/src/main/java/io/cdap/hub/spec/PackageSpec.java
@@ -24,6 +24,7 @@ import java.util.Set;
  * A package specification.
  */
 public class PackageSpec implements Validatable {
+
   private final String specVersion;
   private final String description;
   private final String label;
@@ -34,12 +35,15 @@ public class PackageSpec implements Validatable {
   private final LicenseInfo licenseInfo;
   private final long created;
   private final Boolean beta;
+  private final Boolean preview;
   private final Set<String> categories;
   private final List<ActionSpec> actions;
+  private final Boolean paid;
 
   public PackageSpec(String specVersion, String description, String label, String author, String org,
                      String cdapVersion, String license, LicenseInfo licenseInfo, long created,
-                     Boolean beta, Set<String> categories, List<ActionSpec> actions) {
+                     Boolean beta, Boolean preview, Set<String> categories, List<ActionSpec> actions,
+                     Boolean paid) {
     this.specVersion = specVersion;
     this.description = description;
     this.label = label;
@@ -52,11 +56,15 @@ public class PackageSpec implements Validatable {
     this.license = license;
     this.licenseInfo = licenseInfo;
     this.beta = beta;
+    this.preview = preview;
+    this.paid = paid;
   }
+
 
   public PackageSpec(PackageSpec oldSpec, String newCdapVersion, long newCreated, List<ActionSpec> newActions) {
     this(oldSpec.specVersion, oldSpec.description, oldSpec.label, oldSpec.author, oldSpec.org, newCdapVersion,
-         oldSpec.license, oldSpec.licenseInfo, newCreated, oldSpec.beta, oldSpec.categories, newActions);
+         oldSpec.license, oldSpec.licenseInfo, newCreated, oldSpec.beta, oldSpec.preview, oldSpec.categories,
+         newActions, oldSpec.paid);
   }
 
   public String getSpecVersion() {
@@ -96,7 +104,9 @@ public class PackageSpec implements Validatable {
   }
 
   public Boolean getBeta() {
-    return beta == null ? false : beta;
+    Boolean b = beta == null ? false : beta;
+    Boolean p = preview == null ? false : preview;
+    return b || p;
   }
 
   public Set<String> getCategories() {
@@ -105,6 +115,10 @@ public class PackageSpec implements Validatable {
 
   public List<ActionSpec> getActions() {
     return actions;
+  }
+
+  public Boolean getPaid() {
+    return paid == null ? false : paid;
   }
 
   @Override

--- a/packager/src/main/java/io/cdap/hub/spec/PackageSpec.java
+++ b/packager/src/main/java/io/cdap/hub/spec/PackageSpec.java
@@ -39,11 +39,12 @@ public class PackageSpec implements Validatable {
   private final Set<String> categories;
   private final List<ActionSpec> actions;
   private final Boolean paid;
+  private final String paidLink;
 
   public PackageSpec(String specVersion, String description, String label, String author, String org,
                      String cdapVersion, String license, LicenseInfo licenseInfo, long created,
                      Boolean beta, Boolean preview, Set<String> categories, List<ActionSpec> actions,
-                     Boolean paid) {
+                     Boolean paid, String paidLink) {
     this.specVersion = specVersion;
     this.description = description;
     this.label = label;
@@ -58,13 +59,18 @@ public class PackageSpec implements Validatable {
     this.beta = beta;
     this.preview = preview;
     this.paid = paid;
+    this.paidLink = paidLink;
   }
 
 
   public PackageSpec(PackageSpec oldSpec, String newCdapVersion, long newCreated, List<ActionSpec> newActions) {
     this(oldSpec.specVersion, oldSpec.description, oldSpec.label, oldSpec.author, oldSpec.org, newCdapVersion,
          oldSpec.license, oldSpec.licenseInfo, newCreated, oldSpec.beta, oldSpec.preview, oldSpec.categories,
-         newActions, oldSpec.paid);
+         newActions, oldSpec.paid, oldSpec.paidLink);
+  }
+
+  public String getPaidLink() {
+    return paidLink;
   }
 
   public String getSpecVersion() {

--- a/packager/src/main/java/io/cdap/hub/spec/PackageSpec.java
+++ b/packager/src/main/java/io/cdap/hub/spec/PackageSpec.java
@@ -16,6 +16,8 @@
 
 package io.cdap.hub.spec;
 
+import jdk.internal.joptsimple.internal.Strings;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -38,13 +40,12 @@ public class PackageSpec implements Validatable {
   private final Boolean preview;
   private final Set<String> categories;
   private final List<ActionSpec> actions;
-  private final Boolean paid;
   private final String paidLink;
 
   public PackageSpec(String specVersion, String description, String label, String author, String org,
                      String cdapVersion, String license, LicenseInfo licenseInfo, long created,
                      Boolean beta, Boolean preview, Set<String> categories, List<ActionSpec> actions,
-                     Boolean paid, String paidLink) {
+                     String paidLink) {
     this.specVersion = specVersion;
     this.description = description;
     this.label = label;
@@ -58,7 +59,6 @@ public class PackageSpec implements Validatable {
     this.licenseInfo = licenseInfo;
     this.beta = beta;
     this.preview = preview;
-    this.paid = paid;
     this.paidLink = paidLink;
   }
 
@@ -66,7 +66,7 @@ public class PackageSpec implements Validatable {
   public PackageSpec(PackageSpec oldSpec, String newCdapVersion, long newCreated, List<ActionSpec> newActions) {
     this(oldSpec.specVersion, oldSpec.description, oldSpec.label, oldSpec.author, oldSpec.org, newCdapVersion,
          oldSpec.license, oldSpec.licenseInfo, newCreated, oldSpec.beta, oldSpec.preview, oldSpec.categories,
-         newActions, oldSpec.paid, oldSpec.paidLink);
+         newActions, oldSpec.paidLink);
   }
 
   public String getPaidLink() {
@@ -124,7 +124,7 @@ public class PackageSpec implements Validatable {
   }
 
   public Boolean getPaid() {
-    return paid == null ? false : paid;
+    return !Strings.isNullOrEmpty(paidLink);
   }
 
   @Override


### PR DESCRIPTION
Defined two new properties that can be defined in the spec:

`paid`: boolean value to show/hide the flag, default is false
`paidLink`: string value that represents a link which should give more detail on the charges the user will incur when using this plugin