### PR TITLE
Update class Name

### DIFF
--- a/packages/jdbc-driver-db2/11.1/db2-11-connector.json
+++ b/packages/jdbc-driver-db2/11.1/db2-11-connector.json
@@ -3,7 +3,7 @@
     {
       "name" : "db211",
       "type" : "jdbc",
-      "className" : "com.ibm.db2.jdbc.app.DB2Driver",
+      "className" : "com.ibm.db2.jcc.DB2Driver",
       "description" : "Plugin for the DB2 11 JDBC driver"
     }
   ]


### PR DESCRIPTION
If you download the driver,  and run:
```
jar tf db2jcc4.jar | grep -i DB2Driver
```

The old path: 
`com.ibm.db2.jdbc.app.DB2Driver`

does not exist. Updated to reflect the new path