### PR TITLE
Restrict gcp patch 0.16.2 to 6.3 version

### DIFF
--- a/packages/hydrator-plugin-gcp-plugins/0.16.2/spec.json
+++ b/packages/hydrator-plugin-gcp-plugins/0.16.2/spec.json
@@ -4,7 +4,7 @@
   "label": "Google Cloud Platform",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[6.3.0,7.0.0-SNAPSHOT)",
+  "cdapVersion": "[6.3.0,6.4.0)",
   "created": 1619483183,
   "categories": [
     "hydrator-plugin"


### PR DESCRIPTION
Restrict gcp patch 0.16.2 to 6.3 version since 0.17.1 is available for 6.4.0.