### PR TITLE
Update bouncy castle dependencies to fix security vulnerability

### DIFF
--- a/packager/pom.xml
+++ b/packager/pom.xml
@@ -16,7 +16,7 @@
   -->
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-<modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.cdap.hub</groupId>
   <artifactId>hub-packager</artifactId>
@@ -56,7 +56,7 @@
 
   <properties>
     <aws.version>1.11.22</aws.version>
-    <bouncycastle.version>1.46</bouncycastle.version>
+    <bouncycastle.version>1.71</bouncycastle.version>
     <commons.cli.version>1.2</commons.cli.version>
     <gson.version>2.2.4</gson.version>
     <guava.version>19.0</guava.version>
@@ -115,12 +115,12 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk16</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpg-jdk16</artifactId>
+      <artifactId>bcpg-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### Overview
Currently used bouncy castle dependency bcprov-jdk16 has security vulnerabilities, but the library is not maintained (not updated since 2011 - https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk16).

### Vulnerability details
Vulnerability: Hash Collision affecting org.bouncycastle:bcprov-jdk16
https://nvd.nist.gov/vuln/detail/CVE-2018-5382

### Options
As per https://www.bouncycastle.org/latest_releases.html the recommendation is to move to `jdk18on` or `jdk15to18` jars.
Selected jdk18on since we have source/target java version set to `1.8`. The alternative for older JDK will be to use jdk15to18.

### Changes
The commit updates bouncy castle dependencies `bc[pg,prov]-jdk16` version `1.46` to `bc[pg,prov]-jdk18on` version `1.71`

`Signer.java` is updated to handle breaking changes in the bouncy castle APIs with new jars.
