### PR TITLE
Fix incorrect properties in spec.json

### DIFF
--- a/packages/solution-cdc-oracle-to-kudu/2.0.0/spec.json
+++ b/packages/solution-cdc-oracle-to-kudu/2.0.0/spec.json
@@ -29,12 +29,12 @@
         },
         {
           "name": "config",
-          "value": "cask-cdc-2.0.0-SNAPSHOT.json",
+          "value": "cask-cdc-2.0.0.json",
           "canModify": false
         },
         {
           "name": "jar",
-          "value": "cask-cdc-2.0.0-SNAPSHOT.jar",
+          "value": "cask-cdc-2.0.0.jar",
           "canModify": false
         }
       ]

--- a/packages/solution-cdc-sqlserver-to-hbase/2.0.0/spec.json
+++ b/packages/solution-cdc-sqlserver-to-hbase/2.0.0/spec.json
@@ -29,12 +29,12 @@
         },
         {
           "name": "config",
-          "value": "cask-cdc-2.0.0-SNAPSHOT.json",
+          "value": "cask-cdc-2.0.0.json",
           "canModify": false
         },
         {
           "name": "jar",
-          "value": "cask-cdc-2.0.0-SNAPSHOT.jar",
+          "value": "cask-cdc-2.0.0.jar",
           "canModify": false
         }
       ]


### PR DESCRIPTION
Fixed incorrect version in `config` and `jar` properties of `spec.json` for the following artifacts:

1. solution-cdc-oracle-to-kudu/2.0.0
2. solution-cdc-sqlserver-to-hbase/2.0.0