### PR TITLE
Add sync-regional-buckets job

### DIFF
--- a/.github/scripts/sync.py
+++ b/.github/scripts/sync.py
@@ -15,6 +15,7 @@
 import utilities
 # commands to sync the local repo in the runner to GCS central production bucket
 # -c flag : to compute and compare checksums (instead of comparing mtime) for files
-utilities.run_shell_command('gsutil -m rsync -c -r packages/ gs://hub-cdap-io/v2/packages/')
-utilities.run_shell_command('gsutil cp categories.json gs://hub-cdap-io/v2/categories.json')
-utilities.run_shell_command('gsutil cp packages.json gs://hub-cdap-io/v2/packages.json')
+
+utilities.run_shell_command('gsutil -m rsync -d -c -r -n packages/ gs://${CENTRAL_GCS_BUCKET_PREFIX}/packages/')
+utilities.run_shell_command('gsutil cp categories.json gs://${CENTRAL_GCS_BUCKET_PREFIX}/categories.json')
+utilities.run_shell_command('gsutil cp packages.json gs://${CENTRAL_GCS_BUCKET_PREFIX}/packages.json')

--- a/.github/workflows/hub-release.yml
+++ b/.github/workflows/hub-release.yml
@@ -19,6 +19,9 @@ on:
 concurrency:
   group: automation    # In-order execution by limiting to only 1 workflow run at a time
 
+env:
+  CENTRAL_GCS_BUCKET_PREFIX: "hub-cdap-io/v2"
+
 jobs:
 
   setup-build-and-list-missing-artifacts:    # Job to build packages.json file, find and list missing files
@@ -114,3 +117,25 @@ jobs:
         retry_on: error
         on_retry_command: echo "The upload to central bucket failed in this attempt, retrying...."
         command: python3 ./.github/scripts/sync.py
+
+  sync-regional-buckets:    # Job to sync all regional GCS buckets with central GCS bucket, in parallel
+    runs-on: cdapio-hub-k8-runner
+    needs: merge-missing-artifacts
+    if: success()
+
+    strategy:
+      matrix:
+        loc: [ "us-west1" , "asia-south1", "asia-east1", "asia-east2", "asia-northeast1", "asia-northeast2", "asia-southeast1", "australia-southeast1", "europe-north1", "europe-west1", "europe-west2", "europe-west3", "europe-west4", "europe-west6", "us-central1", "us-east1", "us-east4", "us-west2" ]
+
+    steps:
+
+    - name: Syncing buckets, max 3 retries    # Action to sync bucket, and retry upto 3 times if failed
+      uses: nick-fields/retry@e88a9994b039653512d697de1bce46b00bfe11b5
+      with:
+        timeout_seconds: 180
+        max_attempts: 3
+        retry_on: error
+        on_retry_command: echo "The upload to ${{ matrix.loc }} has failed in this attempt, retrying ..."
+        command: |
+          gsutil -m rsync -d -c -r -n gs://${{ env.GCS_BUCKET_ADDRESS }}/packages gs://cdfhub-${{ matrix.loc }}/hub 
+          gsutil -m cp -r gs://${{ env.GCS_BUCKET_ADDRESS }}/\*.json gs://cdfhub-${{ matrix.loc }}/hub


### PR DESCRIPTION
Added sync regional buckets job, with -n flag for dry run and created environment variable for GCS bucket address, for maintenance later.