### PR TITLE
Fix the command to fetch files from maven central

### DIFF
--- a/.github/workflows/hub-release.yml
+++ b/.github/workflows/hub-release.yml
@@ -91,7 +91,7 @@ jobs:
           echo "${FILENAME} : Found in GCS Bucket"
         else
           echo "${FILENAME} : Not found in GCS Bucket, Fetching from Maven Central"
-          mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:copy -Dartifact=${ID}:${VERSION}:${EXTENSION} -DoutputDirectory=./artifact/
+          mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:copy -Dartifact=${ID}:${EXTENSION} -DoutputDirectory=./artifact/
         fi
 
     - name: Upload Files    # Action to upload the fetched missing file as an artifact


### PR DESCRIPTION
Remove the redundant version field from the maven copy command.
ID is already of the form `GROUP_ID:ARTIFACT_ID:VERSION`
code ref - https://github.com/cdapio/hub/blob/e6ab0e1b885201eaf4bfaecc48ee3c936db719fc/.github/scripts/utilities.py#L91