### PR TITLE
Fix search artifact command in GCS

### DIFF
--- a/.github/workflows/hub-release.yml
+++ b/.github/workflows/hub-release.yml
@@ -76,7 +76,8 @@ jobs:
 
     - name: Fetch from Central Hub GCS if Exists   # Step to copy file from Central Hub GCS bucket if exists
       run: |
-        if [ `gsutil -q stat gs://$CENTRAL_GCS_BUCKET_PREFIX/$FILEPATH | echo $?` -eq 0 ]; 
+        gsutil stat gs://$CENTRAL_GCS_BUCKET_PREFIX/$FILEPATH
+        if [ `echo $?` -eq 0 ];
         then
           gsutil cp -n gs://$CENTRAL_GCS_BUCKET_PREFIX/$FILEPATH artifact/
         else


### PR DESCRIPTION
Separated `echo $?` && `gsutil -q stat gs://$CENTRAL_GCS_BUCKET_PREFIX/$FILEPATH`

Why: When `echo $?` was piped with `gsutil -q stat gs://$CENTRAL_GCS_BUCKET_PREFIX/$FILEPATH` it returned the exit code of previous command.