### PR TITLE
Upgrade actions/checkout to v3 which has node16 support

### DIFF
--- a/.github/workflows/hub-release.yml
+++ b/.github/workflows/hub-release.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
     - name: Repository Checkout    # Action to access file structure of repository in runner
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3
 
     - name: Run Script to Build packages.json    # Step to execute build.py script that performs build operations of this job
       run: python3 ./.github/scripts/build.py
@@ -109,7 +109,7 @@ jobs:
     steps:
 
     - name: Repository Checkout    # Action to access file structure of repository in runner
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3
 
     - name: Download Artifact    # Action to download all the fetched missing files to a temporary artifacts directory
       uses: actions/download-artifact@v3

--- a/.github/workflows/premerge-validation.yml
+++ b/.github/workflows/premerge-validation.yml
@@ -10,14 +10,15 @@ jobs:
     runs-on: ubuntu-latest #running on Github runners
     steps:
     - name: Checkout PR
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Set up JDK 1.8 #to setup Java for building packager
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: 'zulu' # Azul Zulu OpenJDK
+        java-version: '8'
 
     - name: Set up Cloud SDK #to use gsutil commands when searching for necessary files
       uses: google-github-actions/setup-gcloud@v0


### PR DESCRIPTION
Recently we started seeing this warning in github action builds that `Node.js 12 actions are deprecated`.

```
Warning: Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-java

```
This PR helps in upgrading the `actions/checkout` & `actions/setup-java` to `v3` which has node16 support.