### PR TITLE
Remove set-output command with stdout as it will be disabled soon

### DIFF
--- a/.github/scripts/list.py
+++ b/.github/scripts/list.py
@@ -32,7 +32,7 @@ for id in ids:
 jsonStr = ''
 for i in range(len(toFetch)):
     extension = toFetch[i].split('.')[-1]
-    jsonStr += '{\"path\":\"%s\",\"target_path\":\"artifact/%s\",\"artifact\":\"%s\",\"artifactDir\":\"%s\",\"repo\":{\"id\":\"%s\",\"file_type\":\"%s\"}},' %(toFetch[i], toFetch[i].split('/')[3], toFetch[i].split('/')[3], toFetch[i].rsplit('/', 1)[0], ids[i], extension)
+    jsonStr += '{"path":"%s","target_path":"artifact/%s","artifact":"%s","artifactDir":"%s","repo":{"id":"%s","file_type":"%s"}},' %(toFetch[i], toFetch[i].split('/')[3], toFetch[i].split('/')[3], toFetch[i].rsplit('/', 1)[0], ids[i], extension)
 
 output = '[' + jsonStr[:-1] + ']'
 logging.debug('Output of list.py: ')

--- a/.github/workflows/hub-release.yml
+++ b/.github/workflows/hub-release.yml
@@ -46,12 +46,8 @@ jobs:
     - name: Run Script to List Missing Artifact Files    # Step to execute list.py script that performs find and list operations of this job
       run: python3 ./.github/scripts/list.py
 
-    - name: Setting Output    # Step to set resultant list as output of job
-      id: set-matrix
-      run: echo "::set-output name=matrix::${output}"
-
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}    # JSON output containing contents of strategy matrix of next job
+      matrix: ${{ env.output }}    # JSON output containing contents of strategy matrix of next job
 
   fetch-missing-artifacts:    # Job to fetch each missing file individually in parallel
     needs: setup-build-and-list-missing-artifacts


### PR DESCRIPTION
Recently we started seeing this warning in github action builds that `set-output` will be deprecated soon.

```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

```
This PR helps in replacing `set-output` with `environment variable`.